### PR TITLE
docs/summary生成のエンドポイントのドキュメント作成

### DIFF
--- a/docs/api-document.yaml
+++ b/docs/api-document.yaml
@@ -234,6 +234,31 @@ paths:
               schema:
                 $ref: "#/components/schemas/ideaResponse"
 
+  /events/{eventId}/ideas/{ideaId}/summary:
+    post:
+      tags:
+        - "ideas"
+      summary: "Update idea's summary"
+      operationId: "updateSummary"
+      parameters:
+        - name: "eventId"
+          in: path
+          required: true
+          schema:
+            type: "string"
+        - name: "ideaId"
+          in: path
+          required: true
+          schema:
+            type: "string"
+      responses:
+        "200":
+          description: "Update an idea's summary"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ideaResponse"
+
 components:
   schemas:
     createEventInput:


### PR DESCRIPTION
Summary生成のエンドポイント作成しました。

[メモ]
POSTメソッドにしている理由。
- PUT: idempotentな操作に適しており、同じリクエストを繰り返しても結果が同じである必要があります。
- POST: 非idempotentな操作、つまり同じリクエストを繰り返すと毎回異なる結果が得られる場合に適しています。